### PR TITLE
Fix: `.repo-template.config` template repo url

### DIFF
--- a/.repo-template.config
+++ b/.repo-template.config
@@ -1,5 +1,5 @@
 TEMPLATE_AUTO_REJECT=""
 TEMPLATE_REPO_ORIGIN=repo-template
 TEMPLATE_REPO_BRANCH=main
-TEMPLATE_REPO_URL=https://github.com/utkusarioglu/two-sums-trial.git
+TEMPLATE_REPO_URL=https://github.com/utkusarioglu/python-repo-template.git
 TEMPLATE_LAST_COMMIT_EPOCH=1667922600 # 2022-11-08 15:50:00


### PR DESCRIPTION
- Closes #4 by fixing the repo template url that was mistakenly left
  pointing to this repo itself.
