### PR TITLE
Chore: Convert to a workshop

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 {
-  "name": "two-sums-trial.trials.utkusarioglu.com",
+  "name": "python-algo.workshops.utkusarioglu.com",
   "dockerComposeFile": [
     "../.docker/docker-compose.dev.yml",
     "docker-compose.yml"
   ],
-  "service": "two-sums-trial",
-  "workspaceFolder": "/utkusarioglu-com/trials/two-sums-trial",
+  "service": "python-algo-workshop",
+  "workspaceFolder": "/utkusarioglu-com/workshops/python-algo",
   "settings": {
     "workbench.colorCustomizations": {
       "activityBar.background": "#004400"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3.9"
 services:
-  two-sums-trial:
+  python-algo-workshop:
     environment:
       GH_TOKEN: ${GH_TOKEN}
     volumes:
@@ -14,6 +14,6 @@ services:
 
 volumes:
   vscode-extensions:
-    name: two-sums-trial-vscode-extensions
+    name: python-algo-workshop-vscode-extensions
   vscode-extensions-insiders:
-    name: two-sums-trial-vscode-extensions-insiders
+    name: python-algo-workshop-vscode-extensions-insiders

--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -1,11 +1,11 @@
 version: "3.9"
 
 services:
-  two-sums-trial:
+  python-algo-workshop:
     image: utkusarioglu/python-devcontainer:1.0.9
     environment:
-      PYTHONPATH: /utkusarioglu-com/trials/two-sums-trial
+      PYTHONPATH: /utkusarioglu-com/workshops/python-algo
     volumes:
       - type: bind
         source: ..
-        target: /utkusarioglu-com/trials/two-sums-trial
+        target: /utkusarioglu-com/workshops/python-algo

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Python Repo Template
+# Python Algo Workshop
 
-A template repo for my own personal python workshops, and experiments.
+I play with python algo things in this workshop


### PR DESCRIPTION
- Close #17 by converting the repo definitions to a workshop named
  `python-algo`.
- Update readme file to mention the purpose of the repo. The repo is
  missing documentation big time but this is the least we can do.
